### PR TITLE
Update Gemfile, point slack-ruby-bot-server to ~> 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.3.1'
 
-gem 'slack-ruby-bot-server', github: 'dblock/slack-ruby-bot-server'
+gem 'slack-ruby-bot-server', '~> 0.4.0'
 gem 'newrelic-slack-ruby-bot'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,46 +1,25 @@
-GIT
-  remote: git://github.com/dblock/slack-ruby-bot-server.git
-  revision: dd23c2e5104820e434c6fbc67672a65853e92f17
-  specs:
-    slack-ruby-bot-server (0.4.0)
-      celluloid-io
-      foreman
-      grape
-      grape-roar
-      grape-swagger
-      kaminari-mongoid
-      mongoid
-      mongoid-scroll
-      rack-cors
-      rack-rewrite
-      rack-server-pages
-      slack-ruby-bot
-      unicorn
-
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.2.7)
-      actionview (= 4.2.7)
-      activesupport (= 4.2.7)
-      rack (~> 1.6)
-      rack-test (~> 0.6.2)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (5.0.0.1)
+      actionview (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      rack (~> 2.0)
+      rack-test (~> 0.6.3)
+      rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.7)
-      activesupport (= 4.2.7)
+    actionview (5.0.0.1)
+      activesupport (= 5.0.0.1)
       builder (~> 3.1)
       erubis (~> 2.7.0)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    activemodel (4.2.7)
-      activesupport (= 4.2.7)
-      builder (~> 3.1)
-    activesupport (4.2.7)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
     axiom-types (0.1.1)
@@ -72,13 +51,13 @@ GEM
       timers (>= 4.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
-    enumerable-lazy (0.0.1)
     equalizer (0.0.11)
     erubis (2.7.0)
     fabrication (2.15.2)
@@ -86,84 +65,69 @@ GEM
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.2)
+    faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
-    faraday_middleware-parse_oj (0.3.0)
-      faraday (~> 0.9.0)
-      faraday_middleware (~> 0.9.1)
-      oj (~> 2.0)
     foreman (0.82.0)
       thor (~> 0.19.1)
-    giphy (2.0.2)
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.9)
-      faraday_middleware-parse_oj (~> 0.3)
-      launchy (~> 2.4)
     gli (2.14.0)
-    grape (0.17.0)
+    grape (0.18.0)
       activesupport
       builder
       hashie (>= 2.1.0)
       multi_json (>= 1.3.2)
       multi_xml (>= 0.5.2)
-      mustermann19 (~> 0.4.3)
+      mustermann-grape (~> 0.4.0)
       rack (>= 1.3.0)
       rack-accept
       virtus (>= 1.0.0)
     grape-roar (0.3.0)
       grape
       roar (>= 1.0)
-    grape-swagger (0.23.0)
+    grape-swagger (0.24.0)
       grape (>= 0.12.0)
     hashdiff (0.3.0)
-    hashie (3.4.4)
+    hashie (3.4.6)
     hitimes (1.2.4)
     i18n (0.7.0)
     ice_nine (0.11.2)
-    json (1.8.3)
+    json (2.0.2)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kaminari-mongoid (0.1.2)
       kaminari
     kgio (2.10.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
-    mongo (2.2.7)
-      bson (~> 4.0)
-    mongoid (5.1.3)
-      activemodel (~> 4.0)
-      mongo (~> 2.1)
-      origin (~> 2.2)
-      tzinfo (>= 0.3.37)
+    minitest (5.9.1)
+    mongo (2.3.0)
+      bson (~> 4.1)
+    mongoid (6.0.2)
+      activemodel (~> 5.0)
+      mongo (~> 2.3)
     mongoid-compatibility (0.4.0)
       activesupport
       mongoid (>= 2.0)
-    mongoid-scroll (0.3.4)
+    mongoid-scroll (0.3.5)
       i18n
       mongoid (>= 3.0)
       mongoid-compatibility
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mustermann19 (0.4.4)
-      enumerable-lazy
+    mustermann (0.4.0)
+      tool (~> 0.2)
+    mustermann-grape (0.4.0)
+      mustermann (= 0.4.0)
     newrelic-slack-ruby-bot (0.1.0)
       newrelic_rpm
       slack-ruby-bot
-    newrelic_rpm (3.16.0.318)
+    newrelic_rpm (3.17.0.325)
     nio4r (1.2.1)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    oj (2.17.1)
-    origin (2.2.0)
-    pkg-config (1.1.7)
-    rack (1.6.4)
+    rack (2.0.1)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cors (0.4.0)
@@ -172,16 +136,13 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails-deprecated_sanitizer (1.0.3)
-      activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
-      activesupport (>= 4.2.0.beta, < 5.0)
+    rails-dom-testing (2.0.1)
+      activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
-      rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
     raindrops (0.17.0)
-    rake (11.2.2)
+    rake (11.3.0)
     representable (2.3.0)
       uber (~> 0.0.7)
     roar (1.0.4)
@@ -190,7 +151,7 @@ GEM
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.2)
+    rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -200,11 +161,24 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     safe_yaml (1.0.4)
-    slack-ruby-bot (0.8.2)
-      giphy (~> 2.0.2)
+    slack-ruby-bot (0.9.0)
       hashie
       slack-ruby-client (>= 0.6.0)
-    slack-ruby-client (0.7.6)
+    slack-ruby-bot-server (0.4.0)
+      celluloid-io
+      foreman
+      grape
+      grape-roar
+      grape-swagger
+      kaminari-mongoid
+      mongoid
+      mongoid-scroll
+      rack-cors
+      rack-rewrite
+      rack-server-pages
+      slack-ruby-bot
+      unicorn
+    slack-ruby-client (0.7.7)
       activesupport
       faraday
       faraday_middleware
@@ -216,6 +190,7 @@ GEM
     thread_safe (0.3.5)
     timers (4.1.1)
       hitimes
+    tool (0.2.3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -246,7 +221,7 @@ DEPENDENCIES
   newrelic-slack-ruby-bot
   rake
   rspec
-  slack-ruby-bot-server!
+  slack-ruby-bot-server (~> 0.4.0)
   vcr
   webmock
 
@@ -254,4 +229,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.5


### PR DESCRIPTION
Hi @dblock ,
Would you please help review my Pull Request.

**Action**
Update Gemfile, point slack-ruby-bot-server to ~> 0.4.0

**Reason**
Fix [issue 1](https://github.com/slack-ruby/slack-ruby-bot-server-sample/issues/1): Can't re-install SlackApp to SlackTeam
Above bug is fixed in slack-ruby-bot-server v0.4.0 already.
